### PR TITLE
Fix build for examples and tests

### DIFF
--- a/examples/sio_record.d
+++ b/examples/sio_record.d
@@ -11,7 +11,13 @@ import core.stdc.stdlib;
 import core.stdc.string;
 import core.stdc.math;
 import core.stdc.errno;
-import core.sys.posix.unistd;
+
+version (Posix)
+    import core.sys.posix.unistd;
+else version(Windows)
+    import core.sys.windows.winbase;
+else
+    static assert(false);
 
 struct RecordContext {
     SoundIoRingBuffer* ring_buffer;
@@ -279,7 +285,12 @@ int main(int argc, char** argv) {
     // consider a better shutdown strategy.
     for (;;) {
         soundio_flush_events(soundio);
-        sleep(1);
+        version(Posix)
+            sleep(1);
+        else version(Windows)
+            Sleep(1000);
+        else
+            static assert(false);
         int fill_bytes = soundio_ring_buffer_fill_count(rc.ring_buffer);
         char* read_buf = soundio_ring_buffer_read_ptr(rc.ring_buffer);
         size_t amt = fwrite(read_buf, 1, fill_bytes, out_f);

--- a/source/soundio/ring_buffer.d
+++ b/source/soundio/ring_buffer.d
@@ -12,7 +12,7 @@ import soundio.atomics;
 import core.stdc.stdlib;
 import core.atomic;
 
-package struct SoundIoRingBuffer {
+struct SoundIoRingBuffer {
     SoundIoOsMirroredMemory mem;
     shared(size_t) write_offset; // was: SoundIoAtomicULong, but no 64-bit atomics supported on 32-bit windows
     shared(size_t) read_offset; // ditto

--- a/test/backend_disconnect_recover.d
+++ b/test/backend_disconnect_recover.d
@@ -11,7 +11,13 @@ import core.stdc.stdarg;
 import core.stdc.stdlib;
 import core.stdc.string;
 import core.stdc.math;
-import core.sys.posix.unistd;
+
+version (Posix)
+    import core.sys.posix.unistd;
+else version(Windows)
+    import core.sys.windows.winbase;
+else
+    static assert(false);
 
 private void panic(T...)(const(char)* format, T args) {
     printf_stderr(format, args);
@@ -94,7 +100,12 @@ int main(int argc, char** argv) {
 
     if (timeout > 0) {
         printf_stderr("OK sleeping for %d seconds\n", timeout);
-        sleep(timeout);
+        version(Posix)
+            sleep(timeout);
+        else version(Windows)
+            Sleep(timeout * 1000);
+        else
+            static assert(false);
     }
 
     printf_stderr("OK cleaned up. Reconnecting...\n");

--- a/test/latency.d
+++ b/test/latency.d
@@ -50,7 +50,7 @@ private int pulse_frames_left = -1;
 private const(double) PI = 3.14159265358979323846264338328;
 private double seconds_offset = 0.0;
 
-private libsoundio.ring_buffer.SoundIoRingBuffer pulse_rb;
+private soundio.ring_buffer.SoundIoRingBuffer pulse_rb;
 
 private void write_time(SoundIoOutStream* outstream, double extra) {
     double latency;


### PR DESCRIPTION
Hello,

This fixes build of tests and examples (5 out of 8 wouldn't work with LDC 1.27) and make them work on Windows too (`Sleep` vs `sleep`).