### PR TITLE
This fixes a build error with any program using libsoundio-d + --combined + LDC

### DIFF
--- a/source/soundio/api.d
+++ b/source/soundio/api.d
@@ -1181,6 +1181,16 @@ int soundio_instream_get_latency (
     SoundIoInStream* instream,
     double* out_latency);
 
+
+// Note: those function declarations crash LDC when built with --combined
+version(LDC)
+    private enum LDC_predecl_workaround = true;
+else
+    private enum LDC_predecl_workaround = false;
+
+static if (!LDC_predecl_workaround)
+{
+
 struct SoundIoRingBuffer;
 
 /// A ring buffer is a single-reader single-writer lock-free fixed-size queue.
@@ -1219,3 +1229,4 @@ int soundio_ring_buffer_free_count (SoundIoRingBuffer* ring_buffer);
 /// Must be called by the writer.
 void soundio_ring_buffer_clear (SoundIoRingBuffer* ring_buffer);
 
+}


### PR DESCRIPTION
This fixes a build error with any program using libsoundio-d and build with DUB `--combined` and LDC.


The error is the following:

    C:\Users\guill\Desktop\libsoundio-d>dub run --combined libsoundio-d:sine
    Building package libsoundio-d:sine in C:\Users\guill\Desktop\libsoundio-d\
    Performing "debug" build using C:\d\ldc2-1.27.0-beta3-windows-multilib\bin\ldc2.exe for x86_64.
    libsoundio-d:sine 1.0.0+commit.7.g67d2c03: building configuration "application"...
    source\soundio\api.d(1195,20): Error: Function type does not match previously declared function with the same mangled name: `soundio_ring_buffer_create`
    source\soundio\api.d(1195,20):        Previous IR type: %soundio.ring_buffer.SoundIoRingBuffer* (%soundio.api.SoundIo*, i32)
    source\soundio\api.d(1195,20):        New IR type:      %soundio.api.SoundIoRingBuffer* (%soundio.api.SoundIo*, i32)
    C:\d\ldc2-1.27.0-beta3-windows-multilib\bin\ldc2.exe failed with exit code 1.

This removes the forward declaration for ring-buffer, when built with LDC.
I'm not sure if this is an old LDC regression/bug, or legitimate error.